### PR TITLE
Expand tilde in path

### DIFF
--- a/src/conf.py
+++ b/src/conf.py
@@ -104,6 +104,7 @@ def __defaultImgFont():
 
 
 def abspath(path, related_home):
+    path = os.path.expanduser(path)
     return path if os.path.isabs(path) else os.path.join(related_home, path)
 
 


### PR DESCRIPTION
### Steps to reproduce
```bash
$ crudini --set ~/.config/giseditor/giseditor.conf settings mapcache_dir "~/.local/share/giseditor/mapcache"
$ giseditor
```
### Actual behaviour
![giseditor-failed-starup](https://user-images.githubusercontent.com/688044/48958662-b877c500-ef71-11e8-8701-b435d6506a85.png)
### Expected behaviour
~ replaced by that user’s home directory.
### Configuration
GisEditor: 0.26
OS: Linux